### PR TITLE
slurm_deploy: misc fixes

### DIFF
--- a/slurm_deploy/deploy_ctl.sh
+++ b/slurm_deploy/deploy_ctl.sh
@@ -530,6 +530,10 @@ function slurm_prepare_conf()
         SOCKETS=`pdsh -N -w $compute_node lscpu | grep -i "Socket(s)" | cut -d":" -f2 | tr -d '[:space:]'`
         CONTROL_MACHINE=`hostname`
         CFG_NODE_LIST=`get_node_list`
+        
+        if [ -z "$SLURM_JOB_PARTITION" ]; then
+            SLURM_JOB_PARTITION="deploy"
+        fi
 
         #gnerate a confug file
         cat $FILES/local.conf.in | \

--- a/slurm_deploy/files/local.conf.in
+++ b/slurm_deploy/files/local.conf.in
@@ -8,5 +8,5 @@ SlurmdTimeout=300
 
 ClusterName=@cluster_name@
 NodeName=@node_list@            CPUs=@node_cpus@ Sockets=@node_sock_num@ CoresPerSocket=@node_core_per_socket@ ThreadsPerCore=@node_thread_per_core@ State=UNKNOWN
-PartitionName=@partition@       Nodes=@node_list@ DefaultTime=120 Default=NO State=UP AllocNodes=@node_ctl@,@node_list@
+PartitionName=@partition@       Nodes=@node_list@ DefaultTime=120 Default=YES State=UP AllocNodes=@node_ctl@,@node_list@
 ControlMachine=@node_ctl@


### PR DESCRIPTION
- use partition by default (allows do not specify --partition options
  for salloc/srun)
- fix empty partition in slurm.conf when `$SLURM_JOB_PARTITION` not
  defined (for cases when deploy used compute-node as head-node)